### PR TITLE
its working now but still not directed to the home page.

### DIFF
--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 export default function Footer() {
   const navigate = useNavigate();
 
-  const handleNav = (path: string) => () => navigate(path, { replace: true });
+  const handleNav = (path: string) => () => navigate(path); // ✅ Removed replace: true
 
   return (
     <footer className="bg-gray-900">


### PR DESCRIPTION
Absolutely! Here's the fully updated footer.tsx file with the fix applied — I removed the { replace: true } from navigate, so now the back button will return users to the previous page inside your app instead of exiting: