### PR TITLE
the scrolling function is now officialy fixed

### DIFF
--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -5,8 +5,15 @@ export default function Footer() {
   const navigate = useNavigate();
 
   const handleNav = (path: string) => () => {
-    // Navigate directly to the target path
-    navigate(`/${path}`);
+    if (path === "testimonials") {
+      navigate("/", { replace: false });
+      setTimeout(() => {
+        const el = document.getElementById("testimonials");
+        if (el) el.scrollIntoView({ behavior: "smooth" });
+      }, 100);
+    } else {
+      navigate(`/${path}`);
+    }
   };
 
   return (


### PR DESCRIPTION
Modified the handleNav function to handle a special case for the testimonials route.

This ensures that if you're on the homepage (or redirected to it), it scrolls to the element with ID testimonials after a short delay.