### PR TITLE
added the blue colour around the 'Create Company Account' button

### DIFF
--- a/client/src/pages/CompanyRegister.tsx
+++ b/client/src/pages/CompanyRegister.tsx
@@ -156,7 +156,7 @@ const CompanyRegister = () => {
             {/* Submit Button */}
             <Button
               type="submit"
-              className="w-full mt-8 text-lg p-6 font-semibold"
+              className="w-full mt-8 text-lg p-6 font-semibold bg-blue-600 hover:bg-blue-700 text-white border border-blue-700"
               disabled={registerCompanyMutation.isPending}
             >
               {registerCompanyMutation.isPending ? (


### PR DESCRIPTION
Updated the CompanyRegister.tsx file by styling the "Create Company Account" button with a visible blue border, background, and white text for better visibility. Additionally, we confirmed that the "Already have an account?" prompt wasn’t present, so no removal was needed.