### PR TITLE
succesfully added in the 3 new pages

### DIFF
--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -52,18 +52,18 @@ export default function Footer() {
                 </button>
               </li>
               <li>
-                <button onClick={handleNav("internships")} className="text-left text-base text-gray-300 hover:text-white">
-                  Browse Internships
-                </button>
-              </li>
-              <li>
-              <button onClick={handleNav("register")} className="text-left text-base text-gray-300 hover:text-white">
+                <button onClick={handleNav("register")} className="text-left text-base text-gray-300 hover:text-white">
                   Create Profile
                 </button>
               </li>
               <li>
                 <button onClick={handleNav("application-tips")} className="text-left text-base text-gray-300 hover:text-white">
                   Application Tips
+                </button>
+              </li>
+              <li>
+                <button onClick={handleNav("internship-preparation")} className="text-left text-base text-gray-300 hover:text-white">
+                  Internship Preparation
                 </button>
               </li>
             </ul>
@@ -73,16 +73,6 @@ export default function Footer() {
             <h3 className="text-sm font-semibold text-gray-400 tracking-wider uppercase">For Companies</h3>
             <ul className="mt-4 space-y-4">
               <li>
-                <button onClick={handleNav("post-internship")} className="text-left text-base text-gray-300 hover:text-white">
-                  Post Internships
-                </button>
-              </li>
-              <li>
-                <button onClick={handleNav("company/dashboard")} className="text-left text-base text-gray-300 hover:text-white">
-                  Company Dashboard
-                </button>
-              </li>
-              <li>
                 <button onClick={handleNav("internship-guide")} className="text-left text-base text-gray-300 hover:text-white">
                   Internship Guide
                 </button>
@@ -90,6 +80,16 @@ export default function Footer() {
               <li>
                 <button onClick={handleNav("partner-benefits")} className="text-left text-base text-gray-300 hover:text-white">
                   Partner Benefits
+                </button>
+              </li>
+              <li>
+                <button onClick={handleNav("employer-resources")} className="text-left text-base text-gray-300 hover:text-white">
+                  Employer Resources
+                </button>
+              </li>
+              <li>
+                <button onClick={handleNav("industry-insights")} className="text-left text-base text-gray-300 hover:text-white">
+                  Industry Insights
                 </button>
               </li>
             </ul>

--- a/client/src/pages/ InternshipPreparation.tsx
+++ b/client/src/pages/ InternshipPreparation.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export default function InternshipPreparation() {
+  return (
+    <main className="flex-grow bg-gradient-to-b from-white to-gray-100 px-6 py-12">
+      <div className="max-w-4xl mx-auto bg-white rounded-2xl shadow-xl p-10">
+        <h1 className="text-4xl font-extrabold text-blue-700 mb-6 text-center">
+          Internship Preparation
+        </h1>
+        <p className="text-lg text-gray-700 mb-6 text-center">
+          Getting ready for your internship is key to making the most of the experience. Here are some tips to help you prepare:
+        </p>
+        <ul className="list-disc pl-8 space-y-4 text-gray-800 text-base leading-relaxed">
+          <li>
+            <span className="font-semibold text-blue-600">Resume Tips:</span> Craft a clear and concise resume that highlights your skills and achievements.
+          </li>
+          <li>
+            <span className="font-semibold text-blue-600">Interview Skills:</span> Practice common interview questions and learn to present yourself confidently.
+          </li>
+          <li>
+            <span className="font-semibold text-blue-600">Professional Etiquette:</span> Understand workplace norms, punctuality, and communication skills.
+          </li>
+          <li>
+            <span className="font-semibold text-blue-600">Goal Setting:</span> Define what you want to achieve during your internship to stay motivated and focused.
+          </li>
+        </ul>
+        <div className="mt-10 text-center">
+          <p className="text-sm text-gray-500 italic">
+            For more detailed guidance, check out our <a href="/application-tips" className="text-blue-600 underline">Application Tips</a> page.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/ContactUs.tsx
+++ b/client/src/pages/ContactUs.tsx
@@ -1,5 +1,4 @@
 // src/pages/ContactUs.tsx
-import React from "react";
 
 export default function ContactUs() {
   return (

--- a/client/src/pages/EmployerResources.tsx
+++ b/client/src/pages/EmployerResources.tsx
@@ -1,0 +1,19 @@
+export default function EmployerResources() {
+    return (
+      <div className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+        <h1 className="text-4xl font-bold mb-6">Employer Resources</h1>
+        <p className="mb-4">
+          Whether you're new to hosting interns or want to improve your program, these resources will help you create a successful internship experience.
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-gray-700">
+          <li><strong>Hosting Best Practices:</strong> Tips on onboarding, mentoring, and supporting interns effectively.</li>
+          <li><strong>Legal & Compliance:</strong> Understand labor laws and regulations to ensure your internship program is compliant.</li>
+          <li><strong>Maximizing Impact:</strong> Strategies for making internships valuable for both your company and the intern.</li>
+          <li><strong>Feedback & Evaluation:</strong> How to provide meaningful feedback and assess intern performance.</li>
+        </ul>
+        <p className="mt-6">
+          Learn more about how to become a great host on our <a href="/partner-benefits" className="text-green-600 hover:underline">Partner Benefits</a> page.
+        </p>
+      </div>
+    );
+  }

--- a/client/src/pages/IndustryInsights.tsx
+++ b/client/src/pages/IndustryInsights.tsx
@@ -1,0 +1,19 @@
+export default function IndustryInsights() {
+    return (
+      <div className="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+        <h1 className="text-4xl font-bold mb-6">Industry Insights</h1>
+        <p className="mb-4">
+          Stay up to date with the latest trends in internships, skills development, and workforce needs across various industries.
+        </p>
+        <ul className="list-disc list-inside space-y-2 text-gray-700">
+          <li><strong>Emerging Skills:</strong> Discover which skills employers are seeking in interns and graduates.</li>
+          <li><strong>Internship Trends:</strong> Insights into how internship programs are evolving in different sectors.</li>
+          <li><strong>Workforce Development:</strong> The role of internships in shaping the future workforce in South Africa.</li>
+          <li><strong>Success Stories:</strong> Case studies and examples of effective internship programs.</li>
+        </ul>
+        <p className="mt-6">
+          Explore more about internships on our <a href="/" className="text-green-600 hover:underline">Home</a> page.
+        </p>
+      </div>
+    );
+  }


### PR DESCRIPTION
removed the Browse Internships, Company Dashboard, and Post Internship links from your footer to simplify navigation and avoid pages that require sign-in. In their place, we added new publicly accessible pages—Internship Preparation for students, and Employer Resources plus Industry Insights for companies—keeping the footer consistent with your site's theme and encouraging user engagement without login barriers.